### PR TITLE
Bug fix

### DIFF
--- a/run_validations.py
+++ b/run_validations.py
@@ -19,18 +19,19 @@ def set_args():
     parser.add_argument('-i', '--input', help='Path to one file or one directory for validation', required=True)
     parser.add_argument('-s', '--schema', help='Path or URL to schema')
     parser.add_argument('-p', '--file-path', help='Path to the rest of the files for relationship validation')
+    parser.add_argument('-f', '--rel-file', help='Path to the file containing relationship mappings')
     args = parser.parse_args()
     return args
 
-def run_validation_tests(file, path=None):
+def run_validation_tests(file, path=None, rel_file=None):
     """Runs validation tests on a file"""
     try:
         with open(file, 'r') as f:
             data = json.load(f)
     except Exception as e:
-        print(e)
+        raise(e)
     validate = vt.Validate_Tests(data)
-    validation_errors = validate.validate_all(file_path=path)
+    validation_errors = validate.validate_all(file_path=path, rel_file=rel_file)
     return validation_errors
 
 def print_errors(errors,validation_errors):
@@ -64,19 +65,25 @@ def get_files(input):
         raise RuntimeError(f"{input} must be a valid file or directory")
     return files
 
-def validate(input, path = None, schema = None):
+def validate(input, rel_file = None, path = None, schema = None):
     """Runs the files against the schema validator and the class that checks the usecases"""
     files = get_files(input)
     filename = ""
     validation_errors = False
     errors = []
+
+    if (rel_file and not(path)):
+        raise AttributeError(f"Relationship file: {rel_file} must be passed with a --file-path argument which is a path to the rest of the files for relationship validation")
+    elif (rel_file and path):
+        u.arg_exists(rel_file)
+
     for f in files:
         messages = {}
         filename = os.path.basename(f).split(".")[0]
         valid = True
         valid, msg = vs.validate_file(f,schema)
         if valid:
-            messages[filename] = run_validation_tests(f,path)
+            messages[filename] = run_validation_tests(f, path, rel_file)
             if len(messages[filename]) == 0:
                 messages[filename] = None
         else:
@@ -98,8 +105,9 @@ def validate(input, path = None, schema = None):
 def main():
     args = set_args()
     schema = args.schema if args.schema else None
+    rel_file = os.path.normpath(args.rel_file) if args.rel_file else None
     path = os.path.normpath(args.file_path) if args.file_path else None
-    validate(args.input, path, schema)
+    validate(args.input, rel_file, path, schema)
 
 
 if __name__ == "__main__":

--- a/validate/relationships.py
+++ b/validate/relationships.py
@@ -1,8 +1,9 @@
 import json
-import sys
 import os
-import requests
+import re
+from csv import DictReader
 from validate.utilities import *
+import validate.helpers as vh
 
 info = {"file_path": None, "record_info": None}
 errors = []
@@ -20,7 +21,6 @@ def rel_pair_validator(label):
 def rel_values_mapping():
     """Setting up the relationship pairs for institution names"""
     return {"label": "name", "id": "id"}
-
 
 def validate_relationship(file_rel, related_rel):
     err = {}
@@ -69,9 +69,67 @@ def get_related_records(record_id):
             related_record = generate_related_relationships(
                 data['id'], data['name'], data['relationships'])
         except Exception as e:
-            print(f"Couldn't open file {filename}: {e}")
+            raise RuntimeError (f"Couldn't open file {filename}: {e}")
     return related_record
 
+def parse_record_id(id):
+    parsed_id = None
+    pattern = '^https:\/\/ror.org\/(0[a-x|0-9]{8})$'
+    ror_id = re.search(pattern, id)
+    if ror_id:
+        parsed_id = ror_id.group(1)
+    else:
+        errors.append(f"ROR ID: {id} does not match format: {pattern}. Record will not be validated")
+    return parsed_id
+
+def read_relationship_from_file(rel_file):
+    relation = []
+    rel_dict = {}
+    try:
+        with open(rel_file, 'r') as rel:
+            relationships = DictReader(rel)
+            for row in relationships:
+                check_record_id = parse_record_id(row['Record ID'])
+                check_related_id = parse_record_id(row['Related ID'])
+                if (check_record_id and check_related_id): 
+                    rel_dict['short_record_id'] = check_record_id
+                    rel_dict['short_related_id'] = check_related_id
+                    rel_dict['record_id'] = row['Record ID']
+                    rel_dict['related_id'] = row['Related ID']
+                    rel_dict['record_relationship'] = row['Relationship of Related ID to Record ID']
+                    relation.append(rel_dict.copy())
+    except IOError as e:
+        raise RuntimeError(f"Reading file {rel_file}: {e}")
+    return relation
+
+def get_single_related_relationship(related_id):
+    return get_related_records(related_id)
+
+def check_relationships_from_file(current_record, file_path, rel_file):
+    files_exist = []
+    chk_relshp = read_relationship_from_file(rel_file)
+    get_file_ids = list(i['record_id'] for i in chk_relshp)
+    if current_record['id'] in get_file_ids:
+        rel = vh.get_relationship_info()
+        if rel['rel']:
+            info["file_path"] = file_path
+            info["record_info"] = rel
+            all_current_id_relationships = list(i for i in chk_relshp if i['record_id'] == current_record['id'])
+            for r in all_current_id_relationships:
+                file_rel = list(rel for rel in current_record['relationships'] if rel['id'] == r['related_id'])
+                file_rel = file_rel[0]
+                related_relshp = get_related_records(r['related_id'])
+                if related_relshp:
+                    files_exist.append(r['related_id'])
+                    if related_relshp['related_relationship']:
+                        validate_relationship(file_rel, related_relshp)
+                    else:
+                        errors.append(
+                        f"Related relationship not found for {related_relshp['id']}")
+
+    if len(files_exist) == 0:
+        errors.append(f"According to {rel_file}, relationships exist for {current_record['id']}. At least one file listed in relationships must exist")    
+    return errors
 
 def check_relationships():
     files_exist = []
@@ -87,3 +145,16 @@ def check_relationships():
     if len(files_exist) == 0:
         errors.append(f"Relationships exist for {info['record_info']['id']}. At least one file listed in relationships must exist")    
     return errors
+
+def process_relationships(current_record, file_path, rel_file=None):
+    msg = None
+    if rel_file:
+        msg = check_relationships_from_file(current_record, file_path, rel_file)
+    else:
+        rel = vh.get_relationship_info()
+        if rel['rel']:
+            info["file_path"] = file_path
+            info["record_info"] = rel
+            msg = check_relationships()
+    return msg
+    

--- a/validate/relationships.py
+++ b/validate/relationships.py
@@ -117,7 +117,6 @@ def check_relationships_from_file(current_record, file_path, rel_file):
                 file_rel = list(rel for rel in current_record['relationships'] if rel['id'] == r['related_id'])
                 file_rel = file_rel[0]
                 related_relshp = get_related_records(r['related_id'])
-                print("related: ", related_relshp)
                 if related_relshp:
                     files_exist.append(r['related_id'])
                     if related_relshp['related_relationship']:

--- a/validate/utilities.py
+++ b/validate/utilities.py
@@ -4,6 +4,7 @@ import requests
 import json
 import sys
 import validators
+from csv import DictReader
 
 DEFAULT_SCHEMA = "https://raw.githubusercontent.com/ror-community/ror-schema/master/ror_schema.json"
 API_URL = "https://api.ror.org/organizations"
@@ -30,6 +31,29 @@ def get_json(arg,type="file"):
     elif (type == "url"):
         data = get_file_from_url(arg)
     return data
+
+def get_relationship_pairing(file):
+    relation = []
+    rel_dict = {}
+    try:
+        with open(file, 'r') as rel:
+            relationships = DictReader(rel)
+            for row in relationships:
+                check_record_id = parse_record_id(row['Record ID'])
+                check_related_id = parse_record_id(row['Related ID'])
+                if (check_record_id and check_related_id): 
+                    rel_dict['short_record_id'] = check_record_id
+                    rel_dict['short_related_id'] = check_related_id
+                    rel_dict['record_name'] = row['Name of org in Record ID']
+                    rel_dict['record_id'] = row['Record ID']
+                    rel_dict['related_id'] = row['Related ID']
+                    rel_dict['related_name'] = row['Name of org in Related ID']
+                    rel_dict['record_relationship'] = row['Relationship of Related ID to Record ID']
+                    rel_dict['related_location'] = row['Current location of Related ID']
+                    relation.append(rel_dict.copy())
+    except IOError as e:
+        raise RuntimeError(f"Reading file {file}: {e}")
+    return relation
 
 def arg_exists(arg):
     check_path = os.path.exists(arg)

--- a/validate/validation.py
+++ b/validate/validation.py
@@ -74,7 +74,7 @@ class Validate_Tests:
             msg = f'Year value: {yr} should be an integer between 3 and 4 digits'
         return vh.handle_check(name,msg)
 
-    def validate_all(self,file_path=None):
+    def validate_all(self, file_path=None, rel_file=None):
         # calling all public methods in this class and removing the current method name.
         # This enables future public methods to be called automatically as well
         method_name = str(self.validate_all.__name__)
@@ -85,12 +85,9 @@ class Validate_Tests:
             validate = getattr(self, methods)
             results.append(validate())
         if file_path:
-            # if relationship is being checked
-            rel = vh.get_relationship_info()
-            if rel['rel']:
-                vr.info = {"file_path":file_path,"record_info":rel}
-                msg = vr.check_relationships()
-                if msg:
-                    results.append({'relationships':msg})
+             # if relationship is being checked
+            msg = vr.process_relationships(current_record = vh.File, file_path=file_path, rel_file=rel_file)
+            if msg:
+                results.append({'relationships':msg})
         results = list(filter(None,results))
         return results


### PR DESCRIPTION
Fixed
* Use case where relationships are listed in a csv file and passed to the script. The script checks the listed relationships in their respective files instead of all relationships in all files.
* Error reporting where previously processed file errors in the current run were being appended to newer errors.