### PR TITLE
Fix KeyError when Geonames returns empty adminCodes1 object

### DIFF
--- a/validate/helpers.py
+++ b/validate/helpers.py
@@ -206,8 +206,9 @@ def compare_ror_geoname_v2(mapped_fields,ror_address,geonames_response,msg={}):
             geonames_value = None
             if key == 'country_subdivision_code':
                 if value[0] in geonames_response:
-                    if geonames_response[value[0]][value[1]] != "":
-                        geonames_value = geonames_response[value[0]][value[1]]
+                    if isinstance(geonames_response[value[0]], dict) and value[1] in geonames_response[value[0]]:
+                        if geonames_response[value[0]][value[1]] != "":
+                            geonames_value = geonames_response[value[0]][value[1]]
             else:
                 if (value in geonames_response) and (geonames_response[value] != ""):
                     geonames_value = geonames_response[value]


### PR DESCRIPTION
Handle cases where the Geonames API returns an empty adminCodes1 object (e.g., encountered in rc-v1.74 for location ID 785842 - Skopje, North Macedonia) by first checking that the nested ISO3166_2 key exists before accessing it. Fixes resulting validation error: KeyError: 'ISO3166_2' in compare_ror_geoname_v2